### PR TITLE
Updated comment model

### DIFF
--- a/PRDiffr/Comment.swift
+++ b/PRDiffr/Comment.swift
@@ -130,4 +130,5 @@ final class Comment: ResponseObjectSerializable, ResponseCollectionSerializable 
                 completionHandler(response)
             }
     }
+
 }


### PR DESCRIPTION
DOC->>
This is a useless description for a useless code snippet but just want to show that we capture all the 
text between these delimiters.


```
func helloWorld() -> String {
    return "Hello World"
}

let helloWorldStr = helloWorld()
print(helloWorldStr)
```
<<-DOC