### PR TITLE
Updated commit model

### DIFF
--- a/PRDiffr/Commit.swift
+++ b/PRDiffr/Commit.swift
@@ -86,4 +86,5 @@ final class Commit: ResponseObjectSerializable, ResponseCollectionSerializable {
                 completionHandler(response)
         }
     }
+
 }


### PR DESCRIPTION
DOC->>
This is a useless description for a useless code snippet but just want to show that we capture all the 
text between these delimiters.


```
func helloWorld() -> String {
    return "Hello World"
}

let helloWorldStr = helloWorld()
print(helloWorldStr)
```
<<-DOC