### PR TITLE
Updated pr model

### DIFF
--- a/PRDiffr/PullRequest.swift
+++ b/PRDiffr/PullRequest.swift
@@ -191,4 +191,5 @@ final class PullRequest: ResponseObjectSerializable, ResponseCollectionSerializa
                 completionHandler(response)
             }
     }
+
 }


### PR DESCRIPTION
DOC->>
This is a useless description for a useless code snippet but just want to show that we capture all the 
text between these delimiters.


```
func helloWorld() -> String {
    return "Hello World"
}

let helloWorldStr = helloWorld()
print(helloWorldStr)
```
<<-DOC